### PR TITLE
Update main code to current API and some -fpermissive fixes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -22,7 +22,7 @@ int main(){
 	n = 1000;
 	ProgressBar *bar2 = new ProgressBar(n, "Example 2");
 	bar2->SetFrequencyUpdate(10);
-	bar2->SetStyle("|","-");
+	bar2->SetStyle('|','-');
 	//bar2->SetStyle("\u2588", "-"); for linux
 	
 	std::cout << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -13,7 +13,7 @@ int main(){
 	ProgressBar *bar1 = new ProgressBar(n, "Example 1");
 	
 	for(int i=0;i<=n;++i){
-		bar1->Progressed(i);
+		*bar1 += 1;
         std::this_thread::sleep_for (std::chrono::milliseconds(10));
     }
 
@@ -27,28 +27,28 @@ int main(){
 	
 	std::cout << std::endl;
 	for(int i=0;i<=n;++i){
-		bar2->Progressed(i);
+		*bar2 += 1;
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
 	
 	n = 5;
 	ProgressBar bar3(n);
-    bar3.Progressed(0);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(1);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(2);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(3);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(4);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(5);
+    ++bar3;
     // following tests exception error
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(6);
+    ++bar3;
     std::this_thread::sleep_for (std::chrono::milliseconds(200));
-    bar3.Progressed(7);
+    ++bar3;
 
 	return 0;
 }

--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -116,7 +116,7 @@ std::string get_progress_summary(double progress_ratio) {
     std::string buffer = std::string(kCharacterWidthPercentage, ' ');
 
     // in some implementations, snprintf always appends null terminal character
-    snprintf(buffer.data(), kCharacterWidthPercentage,
+    snprintf((char *)buffer.data(), kCharacterWidthPercentage,
              "%5.1f%%", progress_ratio * kTotalPercentage);
 
     // erase the last null terminal character

--- a/progress_bar.hpp
+++ b/progress_bar.hpp
@@ -39,7 +39,7 @@ class ProgressBar {
     bool silent_;
     bool logging_mode_;
     uint64_t total_;
-    std::atomic<uint64_t> progress_ = 0;
+    std::atomic<uint64_t> progress_ = {0};
     uint64_t frequency_update;
     std::ostream *out;
     mutable std::mutex mu_;


### PR DESCRIPTION
* Update main code to current ProgressBar API (increment operators replacing `Progressed()`).
* Fix initialisation of `atomic` object.
* Fixes for compilation using recent GCC (tested with `gcc 10.2.1`) without requiring `-fpermissive`.